### PR TITLE
Change of logic for protocol retrieval and display

### DIFF
--- a/miniurl/const.php
+++ b/miniurl/const.php
@@ -1,7 +1,10 @@
 <?php
+/*** const.php --- Incluye constantes, librerias y funciones necesarias para todo el sistema ***/
+
 class CONS{
 	const BASEURL = "localhost:8080/edsa-mini/i/?";
-	const PROTOCOLOS = array(1=>"HTTP",2=>"HTTPS",3=>"OTRO");
+	//const PROTOCOLOS = array(1=>"HTTP",2=>"HTTPS",3=>"OTRO");
+	//Sacaremos los protocolos de la BD
 }
 
 //Conexion a BD, usando ADO
@@ -14,5 +17,13 @@ if($base->Connect("localhost",'root',"","miniurl")){
 }
 else{
 	die("ERROR EN LA CONEXION A BD");
+}
+
+//Una vez con la BD arriba, sacamos los protocolos
+$sqlProts = "select clave, descripcion as des from cat_protocolo where edo_reg = 1";
+$rsProts = $base->Execute($sqlProts);
+$_PROTOCOLOS = array();
+foreach ($rsProts as $protocolo) {
+	$_PROTOCOLOS[$protocolo['clave']] = $protocolo['des'];
 }
 ?>

--- a/miniurl/getHash.php
+++ b/miniurl/getHash.php
@@ -6,7 +6,8 @@ require_once("const.php");
 $url = $_REQUEST['url'];
 //Si el 'protocolo' es OTRO, usamos el valor de txt
 //if($_REQUEST['protocolo']=='3'){
-$protocolo = $_REQUEST['protTxt'];
+//$protocolo = $_REQUEST['protTxt'];
+$protocolo = $_PROTOCOLOS[$_REQUEST['protocolo']];
 //}
 //$urlCompleto = strtolower(CONS::PROTOCOLOS[$_REQUEST['protocolo']]).'://'.$_REQUEST['url'];
 $urlCompleto = strtolower($protocolo)."://$url";

--- a/miniurl/index.php
+++ b/miniurl/index.php
@@ -36,7 +36,8 @@
 			<div class="col-md-2">
 				<select id="protocolo" name="protocolo" class="form-control">
 					<?php
-					foreach (CONS::PROTOCOLOS as  $cveProt => $abvProt) {
+					//foreach (CONS::PROTOCOLOS as  $cveProt => $abvProt) {
+					foreach($_PROTOCOLOS as $cveProt => $abvProt) {
 						echo "<option value='$cveProt'>$abvProt</option>\n";
 					}
 					?>

--- a/miniurl/stats/index.php
+++ b/miniurl/stats/index.php
@@ -38,7 +38,7 @@ require_once("../const.php");
 							$rs = $base->Execute($sql);
 							foreach ($rs as $registro) {
 								$alias = $registro['hash'];
-								$direccion = strtolower(CONS::PROTOCOLOS[$registro['prot']])."://".$registro['url'];
+								$direccion = strtolower($_PROTOCOLOS[$registro['prot']])."://".$registro['url'];
 								$visitas = $registro['num_visitas'];
 								echo "<tr><td><a href='viewAlias.php?a=$alias'>$alias</a>&nbsp;<a href='graphAlias.php?a=$alias'><button type='button' class='btn btn-default btn-sm'><span class='glyphicon glyphicon-picture' aria-hidden='true'></span></button></a></td><td><a href='$direccion'>$direccion<a></td><td>$visitas</td><td>&nbsp;</td></tr>";
 							}


### PR DESCRIPTION
Part of the optimization of the code to make it backwards compatible
with PHP 5.4, the use of array constants was eliminated. Protocols are
now retrieved via DB lookup. Other scripts where change accordingly.
Cleanup is required, but the fix is done.
