### PR TITLE
Adding no link notice

### DIFF
--- a/miniurl/i/index.php
+++ b/miniurl/i/index.php
@@ -21,10 +21,17 @@
 		if($rs->fields['log'] == "1"){
 			$ip = $_SERVER['REMOTE_ADDR'];
 			$user_agent = $_SERVER['HTTP_USER_AGENT'];
-			$browser = get_browser(null,true);
-			$nombreBrowser = $browser['browser'];
-			$sisop = $browser['platform'];
-			$sqlLog = "insert into visitas (ip,user_agent,browser,sisop,id_enlace) values ('$ip','$user_agent','$nombreBrowser','$sisop',".$rs->fields['id'].")";
+			$showBrowserData = true;
+			if(!ini_get('browscap')) $showBrowserData = false;
+			if($showBrowserData){
+				$browser = get_browser(null,true);
+				$nombreBrowser = $browser['browser'];
+				$sisop = $browser['platform'];
+				$sqlLog = "insert into visitas (ip,user_agent,browser,sisop,id_enlace) values ('$ip','$user_agent','$nombreBrowser','$sisop',".$rs->fields['id'].")";
+			}
+			else{
+				$sqlLog = "insert into visitas (ip,user_agent,id_enlace) values ('$ip','$user_agent',".$rs->fields['id'].")";
+			}
 			//die($sqlLog);
 			$rsLog = $base->Execute($sqlLog);
 		}

--- a/miniurl/stats/index.php
+++ b/miniurl/stats/index.php
@@ -1,5 +1,5 @@
 <?php
-/*** stats/index.php -- Index de las estadísticas ***/
+/*** stats/index.php -- Statistics index view ***/
 require_once($_SERVER['DOCUMENT_ROOT'].'/const.php');
 session_start();
 if(!isset($_SESSION['authToken']) || !isset($_SESSION['uid'])){
@@ -34,11 +34,20 @@ include_once($_SERVER['DOCUMENT_ROOT'].'/header.php');
 						<?php
 							$sql = "select hash,url,cve_protocolo as prot,count(*) as num_visitas from enlaces,visitas where enlaces.id = visitas.id_enlace and seLogea = true and enlaces.id_user = $uid group by id_enlace";
 							$rs = $base->Execute($sql);
-							foreach ($rs as $registro) {
-								$alias = $registro['hash'];
-								$direccion = strtolower($_PROTOCOLOS[$registro['prot']])."://".$registro['url'];
-								$visitas = $registro['num_visitas'];
-								echo "<tr><td class='text-right'><a href='viewAlias.php?a=$alias'>$alias</a>&nbsp;</td><td><a href='graphAlias.php?a=$alias'><button type='button' class='btn btn-default btn-sm'><span class='glyphicon glyphicon-picture' aria-hidden='true'></span></button></a></td><td><a href='$direccion'>$direccion<a></td><td class='text-center'>$visitas</td><td>&nbsp;</td></tr>";
+							if($rs->RecordCount()>0){
+								foreach ($rs as $registro) {
+									$alias = $registro['hash'];
+									$direccion = strtolower($_PROTOCOLOS[$registro['prot']])."://".$registro['url'];
+									$visitas = $registro['num_visitas'];
+									echo "<tr><td class='text-right'><a href='viewAlias.php?a=$alias'>$alias</a>&nbsp;</td><td><a href='graphAlias.php?a=$alias'><button type='button' class='btn btn-default btn-sm'><span class='glyphicon glyphicon-picture' aria-hidden='true'></span></button></a></td><td><a href='$direccion'>$direccion<a></td><td class='text-center'>$visitas</td><td>&nbsp;</td></tr>";
+								}
+							}
+							else{
+								?>
+								<tr>
+									<td colspan="5">You haven't created any links with the option to log them yet :=(</td>
+								</tr>
+								<?php
 							}
 						?>
 					</tbody>


### PR DESCRIPTION
If there are no tracked links created, the view shows a message about
that, in the same UI section where the links list should be.
Also, solved an issue where, in servers not supporting browscap, the
link creation script threw warnings and ultimately prevented the link to
be created.
