### PR TITLE
Wrong error message in short but valid URL

### DIFF
--- a/miniurl/index.js
+++ b/miniurl/index.js
@@ -43,7 +43,7 @@ $(document).ready(function(){
 		else{
 			$.getJSON("getHash.php",{"protocolo": newLink.keyProtocol, "protTxt": newLink.protocol, "url": newLink.url},function(response){
 				$("#alias-group").removeClass("has-success has-error");
-				if((response.existe==true)||newLink.url.length<8){ //TODO: Check if the second clause of the condition is needed
+				if((response.existe==true)||newLink.url.length<4){ //TODO: Check if the second clause of the condition is needed
 					cambiarUIpostHash("The URL has already been minimized",'red',false);
 					$("#alias").val(response.hash);
 					newLink.isValid = false;


### PR DESCRIPTION
There was a hard, left-over validation that returned false if the length
of the URL was less than eight. The URL is now at least 4 chars, not 8.
The alias generated was new, but the validation function marked the
alias as 'has-error', and the message was about the existance, which was
not the case. Fixed.
